### PR TITLE
Fix require() statement

### DIFF
--- a/lua/psql.lua
+++ b/lua/psql.lua
@@ -1,4 +1,4 @@
-local u = require("util")
+local u = require("util.init")
 
 local SETTINGS = {
 	connection = {


### PR DESCRIPTION
fixes this ugly error:

```
E5108: Error executing lua /Users/user/.local/share/nvim/lazy/psql.nvim/lua/psql.lua:26: attempt to ca
ll field 'run_query' (a nil value)
stack traceback:
        /Users/user/.local/share/nvim/lazy/psql.nvim/lua/psql.lua:26: in function 'query_current_line'
        [string ":lua"]:1: in main chunk

```